### PR TITLE
Add instructions for using PackageResourceViewer, some grammar changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ColorSchemeEditor
 =================
-"Real-time" color scheme editor plugin for Sublime Text 2/3.
+Real-time color scheme editor plugin for Sublime Text 2/3.
 
 Screenshots
 ===========
@@ -15,13 +15,13 @@ Screenshots
 
 Usage
 =====
-- Activate the color scheme you want to edit (**it must be editable file on your disk, not file inside `.sublime-package`, aka `.zip`. You can unzip it, put it in your packages folder somewhere, e.g. `Packages/SomeWhere`, select the theme and then you can use this plugin**).
-- Open some file and press Shift+F12.
-- Your color scheme should open in separate pane.
+- Activate the color scheme you want to edit. **it must be an editable file on your disk, not inside a `.sublime-package`.** If you are using Sublime Text 3 and your theme is inside a package, install the [`PackageResourceViewer`](https://packagecontrol.io/packages/PackageResourceViewer) plugin, open the Command Palette, type ***prv***, and select **`PackageResourceViewer: Open Resource`**. Scroll down until you find the name of the package you want (the built-in color schemes are in `Color Scheme - Default`) and hit Enter. You can now find the `.tmTheme` file you want and hit Enter. The interface allows you to select more files, just hit Escape when you're done. Now, finally, you need to select **`File -> Save`** for each file you extracted, or it won't show up in your `Packages` folder (**`Preferences -> Browse Packages...`**). Once you're done, you can close the `.tmTheme` file tabs.
+- Open some code and press Shift+F12.
+- Your color scheme should open in a separate pane.
 - As you put the cursor on different source elements, the other pane will find and display the XML element that is affecting this element.
-- If more than one style element affect the code element, the most relevant style match is displayed first and you can go to other matches with Ctrl+Alt+Right and Ctrl+Alt+Left.
+- If more than one style element affects the code element, the most relevant style match is displayed first. You can go to the other matches with `Ctrl+Alt+Right` and `Ctrl+Alt+Left`.
 - Change the styles as you wish and save so Sublime Text will reload the styles and display your changes.
-- When you are done editing press Shift+F12 again or close the view of the scheme file.
+- When you are done editing press Shift+F12 again or close the view of the color scheme file.
 
 Authors
 =======


### PR DESCRIPTION
Instead of having to manually unzip `.sublime-package` files, edit the contents, then rezip the archive and copy it back to `Installed Packages`, I added info for using `PackageResourceViewer`, which is a fantastically useful plugin.

I also fixed a couple of grammatical errors and issues where the words didn't "flow" properly, I hope you don't mind :grinning:
