### PR TITLE
General Improvements

### DIFF
--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -73,7 +73,7 @@ def update_view_status ( view ):
 		regex += ')( ?, ?[a-z\\.\\-]*)*</string>'
 
 		found = _schemeEditor.find_all( regex, 0 )
-		found = find_matches( scope_name, found )
+		found = find_matches( scope, found )
 		if found != None:
 			_lastScope += found
 

--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -2,7 +2,7 @@ import sublime, sublime_plugin, os.path
 
 # globals suck, but don't know how to pass data between the classes
 _schemeEditor = None
-_skipOne = 0
+_skipNext = False
 _wasSingleLayout = None
 _lastScope = None
 _lastScopeIndex = 0
@@ -89,14 +89,14 @@ def update_view_status ( view ):
 
 
 def kill_scheme_editor ():
-	global _schemeEditor, _skipOne, _wasSingleLayout, _lastScope, _lastScopeIndex
+	global _schemeEditor, _skipNext, _wasSingleLayout, _lastScope, _lastScopeIndex
 	if int( sublime.version() ) > 3000 and _wasSingleLayout != None:
 		_wasSingleLayout.set_layout( {
 			'cols': [0.0, 1.0],
 			'rows': [0.0, 1.0],
 			'cells': [[0, 0, 1, 1]]
 		} )
-	_skipOne = 0
+	_skipNext = False
 	_wasSingleLayout = None
 	_schemeEditor = None
 	_lastScope = None
@@ -115,15 +115,15 @@ class NavigationListener ( sublime_plugin.EventListener ):
 				kill_scheme_editor()
 
 	def on_selection_modified ( self, view ):
-		global _schemeEditor, _skipOne
+		global _schemeEditor, _skipNext
 
 		if _schemeEditor != None:
 			if _schemeEditor.id() != view.id() and not view.settings().get( 'is_widget' ):
 				# for some reason this callback is called twice - for mouse down and mouse up
-				if _skipOne == 1:
-					_skipOne = 0
+				if _skipNext:
+					_skipNext = False
 				else:
-					_skipOne = 1
+					_skipNext = True
 					update_view_status( view )
 
 

--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -65,12 +65,12 @@ def update_view_status ( view ):
 		if len( scope ) == 0:
 			continue
 		dots = scope.count( '.' )
-		regex = '<key>scope</key>\\s*<string>([a-z\\.\\-]* ?, ?)*([a-z\\.\\- ]*'
-		regex += scope.replace( '.', '(\\.' )
+		regex = r'<key>scope</key>\s*<string>([a-z\.\-\+]* ?, ?)*([a-z\.\-\+ ]*'
+		regex += scope.replace( '.', r'(\.' )
 		while dots > 0:
 			regex += ')?'
 			dots -= 1
-		regex += ')( ?, ?[a-z\\.\\-]*)*</string>'
+		regex += r')( ?, ?[a-z\.\-\+]*)*</string>'
 
 		found = _schemeEditor.find_all( regex, 0 )
 		found = find_matches( scope, found )

--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -119,12 +119,20 @@ class NavigationListener ( sublime_plugin.EventListener ):
 
 		if _schemeEditor != None:
 			if _schemeEditor.id() != view.id() and not view.settings().get( 'is_widget' ):
-				# for some reason this callback is called twice - for mouse down and mouse up
 				if _skipNext:
 					_skipNext = False
 				else:
-					_skipNext = True
 					update_view_status( view )
+
+
+	def on_text_command( self, view, command_name, args ):
+		global _schemeEditor, _skipNext
+
+		# `on_selection_modified` will fire twice every time a left-click
+		# occurs; once on mouse-down, once on mouse-up. `on_text_command` will
+		# only fire on mouse-down, so we can use that event to flag a skip.
+		if _schemeEditor != None and command_name == "drag_select":
+			_skipNext = True
 
 
 

--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -7,13 +7,14 @@ _wasSingleLayout = None
 _lastScope = None
 _lastScopeIndex = 0
 
+
 def find_matches ( scope, founds ):
 	global _schemeEditor
 
 	ret = []
 	maxscore = 0
-	# find the scope in the xml that matches the most
 
+	# find the scope in the xml that matches the most
 	for found in founds:
 		foundstr = _schemeEditor.substr( found )
 		pos = foundstr.find( '<string>' ) + 8
@@ -26,7 +27,6 @@ def find_matches ( scope, founds ):
 			padleft = fstrlen - len( fstr )
 			fstr = fstr.rstrip( ' ' )
 			score = sublime.score_selector( scope, fstr )
-			# print( fstr, score )
 			if score > 0:
 				a = found.a + pos + padleft
 				ret.append( [ score, sublime.Region( a, a + len( fstr ) ) ] )
@@ -37,9 +37,11 @@ def find_matches ( scope, founds ):
 	else:
 		return ret
 
+
 def display_scope ( region ):
 	global _schemeEditor
-	# doest change the selection if previous selection was on the same line
+
+	# doesn't change the selection if previous selection was on the same line
 	sel = _schemeEditor.sel()
 	sel.clear()
 	sel.add( region )
@@ -47,18 +49,17 @@ def display_scope ( region ):
 
 
 def update_view_status ( view ):
-
 	global _lastScope, _lastScopeIndex
 
 	found = None
 	_lastScope = []
 	_lastScopeIndex = 0
-	
+
 	# find the scope under the cursor
 	scope_name = view.scope_name( view.sel()[0].a )
 	pretty_scope = scope_name.strip( ' ' ).replace( ' ', ' > ' )
 	scopes = reversed( pretty_scope.split( ' > ' ) )
-	
+
 	# convert to regex and look for the scope in the scheme editor
 	for scope in scopes:
 		if len( scope ) == 0:
@@ -71,14 +72,11 @@ def update_view_status ( view ):
 			dots -= 1
 		regex += ')( ?, ?[a-z\\.\\-]*)*</string>'
 
-		# print( regex )
 		found = _schemeEditor.find_all( regex, 0 )
 		found = find_matches( scope_name, found )
-		# print( found )
 		if found != None:
 			_lastScope += found
 
-	# print( _lastScope )
 	scopes = len( _lastScope )
 	sublime.status_message( 'matches ' + str( scopes ) + ': ' + pretty_scope )
 	if scopes == 0:
@@ -105,17 +103,20 @@ def kill_scheme_editor ():
 	_lastScopeIndex = 0
 
 
+
 # listeners to update our scheme editor
 class NavigationListener ( sublime_plugin.EventListener ):
 
 	def on_close ( self, view ):
 		global _schemeEditor
+
 		if _schemeEditor != None:
 			if _schemeEditor.id() == view.id():
 				kill_scheme_editor()
 
 	def on_selection_modified ( self, view ):
 		global _schemeEditor, _skipOne
+
 		if _schemeEditor != None:
 			if _schemeEditor.id() != view.id() and not view.settings().get( 'is_widget' ):
 				# for some reason this callback is called twice - for mouse down and mouse up
@@ -126,7 +127,9 @@ class NavigationListener ( sublime_plugin.EventListener ):
 					update_view_status( view )
 
 
+
 class EditColorSchemeNextScopeCommand ( sublime_plugin.TextCommand ):
+
 	def run ( self, edit ):
 		global _schemeEditor, _lastScope, _lastScopeIndex
 
@@ -142,6 +145,7 @@ class EditColorSchemeNextScopeCommand ( sublime_plugin.TextCommand ):
 
 
 class EditColorSchemePrevScopeCommand ( sublime_plugin.TextCommand ):
+
 	def run ( self, edit ):
 		global _schemeEditor, _lastScope, _lastScopeIndex
 
@@ -157,10 +161,10 @@ class EditColorSchemePrevScopeCommand ( sublime_plugin.TextCommand ):
 
 
 class EditCurrentColorSchemeCommand ( sublime_plugin.TextCommand ):
-	
+
 	def run ( self, edit ):
 		global _schemeEditor, _wasSingleLayout
-		
+
 		view = self.view
 		viewid = view.id()
 		window = view.window()
@@ -210,7 +214,7 @@ class EditCurrentColorSchemeCommand ( sublime_plugin.TextCommand ):
 			else:
 				#if the editor is in different splitter already focus it
 				window.focus_view( _schemeEditor )
-			
+
 			window.focus_view( view )
 			update_view_status( view )
 
@@ -223,7 +227,3 @@ class EditCurrentColorSchemeCommand ( sublime_plugin.TextCommand ):
 					'cells': [[0, 0, 1, 1]]
 				} )
 			kill_scheme_editor()
-			
-
-		
-		

--- a/ColorSchemeEditor-ST2.py
+++ b/ColorSchemeEditor-ST2.py
@@ -140,11 +140,17 @@ class NavigationListener ( sublime_plugin.EventListener ):
 	def on_text_command( self, view, command_name, args ):
 		global _schemeEditor, _skipNext
 
-		# `on_selection_modified` will fire twice every time a left-click
-		# occurs; once on mouse-down, once on mouse-up. `on_text_command` will
-		# only fire on mouse-down, so we can use that event to flag a skip.
-		if _schemeEditor != None and command_name == "drag_select":
-			_skipNext = True
+		if _schemeEditor != None:
+			if command_name == "drag_select":
+				# The 'drag_select' text command only fires once (on mouse-down)
+				# but `on_selection_modified` fires twice (on mouse-down and
+				# mouse-up). Use the 'drag_select' command to trigger a skip.
+				_skipNext = True
+			elif command_name == "show_scope_name":
+				# 'show_scope_name' triggers `on_selection_modified` for some
+				# reason. Skip the next `on_selection_modified` when we see a
+				# 'show_scope_name'.
+				_skipNext = True
 
 
 

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,56 @@
+[
+
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Color Scheme Editor",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/ColorSchemeEditor/Default.sublime-keymap",
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
- Correctly find/select scopes that end with `.c++`
- Always redraw selections -- even when the new region is on the same line as the previous
- More precisely skip detections on mouse-down and on `show_scope_name`
- General code/comment cleanups.
